### PR TITLE
Automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,11 @@ jobs:
         include:
           - runner: ubicloud-standard-2
             platform: x64
+            edk2_version: edk2-stable202402
+            edk2_commit: edc6681206c1a8791981a2f911d2fb8b3d2f5768
           - runner: ubicloud-standard-2-arm
+            edk2_version: edk2-stable202211
+            edk2_commit: fff6d81270b57ee786ea18ad74f43149b9f03494
             platform: arm64
 
     steps:
@@ -19,12 +23,14 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y install uuid-dev iasl build-essential python3-distutils git libbrotli-dev nasm
       - name: Build edk2
-        run: ./build-edk2
+        run: EDK2_COMMIT=${{ matrix.edk2_commit}} ./build-edk2
       - name: List produced files
         run: ls
       - uses: ncipollo/release-action@v1
-        if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'
+        if: github.event_name == 'workflow_dispatch'
         with:
           artifacts: "${{ github.workspace }}/CLOUDHV-${{ matrix.platform }}.fd"
-          body: "Release ${{ github.ref_name }}"
+          body: "Release ${{ matrix.edk2_version }}-${{ matrix.platform }}"
+          name: "${{ matrix.edk2_version }}-${{ matrix.platform }}"
+          tag: "${{ matrix.edk2_version }}-${{ matrix.platform }}"
           allowUpdates: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,17 @@
 name: edk2 build
-on: [create,push]
+on: [push,workflow_dispatch]
 
 jobs:
   build:
-    name: Build
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runs-on: [ubicloud, ubicloud-arm]
-    runs-on: ${{matrix.runs-on}}
+        include:
+          - runner: ubicloud-standard-2
+            platform: x64
+          - runner: ubicloud-standard-2-arm
+            platform: arm64
 
     steps:
       - name: Code checkout
@@ -18,3 +22,9 @@ jobs:
         run: ./build-edk2
       - name: List produced files
         run: ls
+      - uses: ncipollo/release-action@v1
+        if: github.event_name == 'workflow_dispatch' && github.ref_type == 'tag'
+        with:
+          artifacts: "${{ github.workspace }}/CLOUDHV-${{ matrix.platform }}.fd"
+          body: "Release ${{ github.ref_name }}"
+          allowUpdates: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+edk2_build/*
+*.fd

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ the following in a Debian or Ubuntu environment:
 # If you need build dependencies:
 $ sudo apt-get update && sudo apt-get -y install uuid-dev iasl build-essential python3-distutils git libbrotli-dev nasm
 
-$ ./build-edk2
+$ EDK2_COMMIT=edc6681206c1a8791981a2f911d2fb8b3d2f5768 ./build-edk2
 ```

--- a/build-edk2
+++ b/build-edk2
@@ -92,6 +92,7 @@ build_edk2() {
               ! -f "$EDK2_PLAT_DIR/.built" ||
               ! -f "$ACPICA_DIR/.built" ]]; then
         pushd "$EDK2_BUILD_DIR" || exit
+
         # Build
         make -C acpica -j "$(nproc)"
         # shellcheck disable=SC1091
@@ -108,6 +109,8 @@ build_edk2() {
             build -a X64 -t GCC5 -p OvmfPkg/CloudHv/CloudHvX64.dsc -b RELEASE -n 0
             cp Build/CloudHvX64/RELEASE_GCC5/FV/CLOUDHV.fd "$WORKLOADS_DIR/CLOUDHV-x64.fd"
         elif [ "$architecture" = "aarch64" ]; then
+            # We don't need the "Press ESCAPE for boot options" prompt
+            sed -i 's/\(gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|\)[0-9]\+/\10/g' edk2/ArmVirtPkg/ArmVirtCloudHv.dsc
             build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtCloudHv.dsc -b RELEASE -n 0
             cp Build/ArmVirtCloudHv-AARCH64/RELEASE_GCC5/FV/CLOUDHV_EFI.fd "$WORKLOADS_DIR/CLOUDHV-arm64.fd"
         else

--- a/build-edk2
+++ b/build-edk2
@@ -12,11 +12,15 @@
 # sudo -- bash -c 'apt-get update && apt-get install -y make gcc g++ flex bison nasm m4 uuid-dev g++'
 
 WORKLOADS_DIR="$(pwd)"
-EDK2_COMMIT="8736b8fdca85e02933cdb0a13309de14c9799ece"
-EDK2_PLAT_COMMIT="b5fa396700e728c0e18b512229226f65337bf74a"
+EDK2_PLAT_COMMIT="103c88ba5b0c6259fc674e6358c68a85e882e41b"
 ACPICA_COMMIT="f16a0b4d0f0edd7b78a332fcf507be2187fac21e"
 
 set -uex
+
+if [ -z "$EDK2_COMMIT" ]; then
+  echo "Error: EDK2_COMMIT is not set." >&2
+  exit 1
+fi
 
 # Checkout source code of a GIT repo with specified branch and commit
 # Args:

--- a/build-edk2
+++ b/build-edk2
@@ -91,7 +91,7 @@ build_edk2() {
         # Build
         make -C acpica -j "$(nproc)"
         # shellcheck disable=SC1091
-        
+
         # edk2setup relies on null expansions.
         set -xe +u
         source edk2/edksetup.sh
@@ -102,10 +102,10 @@ build_edk2() {
 
         if [ "$architecture" = "x86_64" ]; then
             build -a X64 -t GCC5 -p OvmfPkg/CloudHv/CloudHvX64.dsc -b RELEASE -n 0
-            cp Build/CloudHvX64/RELEASE_GCC5/FV/CLOUDHV.fd "$WORKLOADS_DIR"
+            cp Build/CloudHvX64/RELEASE_GCC5/FV/CLOUDHV.fd "$WORKLOADS_DIR/CLOUDHV-x64.fd"
         elif [ "$architecture" = "aarch64" ]; then
             build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtCloudHv.dsc -b RELEASE -n 0
-            cp Build/ArmVirtCloudHv-AARCH64/RELEASE_GCC5/FV/CLOUDHV_EFI.fd "$WORKLOADS_DIR"
+            cp Build/ArmVirtCloudHv-AARCH64/RELEASE_GCC5/FV/CLOUDHV_EFI.fd "$WORKLOADS_DIR/CLOUDHV-arm64.fd"
         else
             echo "Unsupported architecture: $architecture"
         fi


### PR DESCRIPTION
An example release: https://github.com/ubicloud/build-edk2-test/releases/tag/v1

- Creates two releases if manually triggered, one for each platform.
- Uses edk2-stable202402 for x64 and edk2-stable202411 for arm64.
- Disables the "Press ESCAPE for boot options" prompt in arm64, which will improve provisioning times by few seconds.
